### PR TITLE
Replaced obsolete nerd font icons

### DIFF
--- a/rofi-wifi-menu.sh
+++ b/rofi-wifi-menu.sh
@@ -6,9 +6,9 @@ wifi_list=$(nmcli --fields "SECURITY,SSID" device wifi list | sed 1d | sed 's/  
 
 connected=$(nmcli -fields WIFI g)
 if [[ "$connected" =~ "enabled" ]]; then
-	toggle="睊  Disable Wi-Fi"
+	toggle="󰖪  Disable Wi-Fi"
 elif [[ "$connected" =~ "disabled" ]]; then
-	toggle="直  Enable Wi-Fi"
+	toggle="󰖩  Enable Wi-Fi"
 fi
 
 # Use rofi to select wifi network
@@ -18,9 +18,9 @@ chosen_id=$(echo "${chosen_network:3}" | xargs)
 
 if [ "$chosen_network" = "" ]; then
 	exit
-elif [ "$chosen_network" = "直  Enable Wi-Fi" ]; then
+elif [ "$chosen_network" = "󰖩  Enable Wi-Fi" ]; then
 	nmcli radio wifi on
-elif [ "$chosen_network" = "睊  Disable Wi-Fi" ]; then
+elif [ "$chosen_network" = "󰖪  Disable Wi-Fi" ]; then
 	nmcli radio wifi off
 else
 	# Message to show when connection is activated successfully


### PR DESCRIPTION
Some of the nerd font icons in this project were effected by the recent [change](https://github.com/ryanoasis/nerd-fonts/releases/tag/v2.3.3) to the nerd font project and needed to be updated. This pr should replace all depreciated icons.