### PR TITLE
Fix for SSIDs with special characters

### DIFF
--- a/rofi-wifi-menu.sh
+++ b/rofi-wifi-menu.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-notify-send "Getting list of available Wi-Fi networks..."
+notify-send "Information"  "<span font='10px'><i><b>Getting list of available Wi-Fi networks...</b></i></span>"
 # Get a list of available wifi connections and morph it into a nice-looking list
 wifi_list=$(nmcli --fields "SECURITY,SSID" device wifi list | sed 1d | sed 's/  */ /g' | sed -E "s/WPA*.?\S/ /g" | sed "s/^--/ /g" | sed "s/  //g" | sed "/--/d")
 
@@ -14,7 +14,7 @@ fi
 # Use rofi to select wifi network
 chosen_network=$(echo -e "$toggle\n$wifi_list" | uniq -u | rofi -dmenu -i -selected-row 1 -p "Wi-Fi SSID: " )
 # Get name of connection
-chosen_id=$(echo "${chosen_network:3}" | xargs)
+read -r chosen_id <<< "${chosen_network:3}"
 
 if [ "$chosen_network" = "" ]; then
 	exit
@@ -24,15 +24,17 @@ elif [ "$chosen_network" = "󰖪  Disable Wi-Fi" ]; then
 	nmcli radio wifi off
 else
 	# Message to show when connection is activated successfully
-	success_message="You are now connected to the Wi-Fi network \"$chosen_id\"."
+	success_message="<span font='10px'><i><b>Connection Established! You are now connected to the Wi-Fi network $chosen_id.</b></i></span>"
 	# Get saved connections
 	saved_connections=$(nmcli -g NAME connection)
 	if [[ $(echo "$saved_connections" | grep -w "$chosen_id") = "$chosen_id" ]]; then
-		nmcli connection up id "$chosen_id" | grep "successfully" && notify-send "Connection Established" "$success_message"
+		nmcli connection up id "$chosen_id" | grep "successfully" && notify-send  "Information" "$success_message"
 	else
 		if [[ "$chosen_network" =~ "" ]]; then
 			wifi_password=$(rofi -dmenu -p "Password: " )
 		fi
-		nmcli device wifi connect "$chosen_id" password "$wifi_password" | grep "successfully" && notify-send "Connection Established" "$success_message"
+		nmcli device wifi connect "$chosen_id" password "$wifi_password" | grep "successfully" && notify-send "Information" "<span font='10px'><i><b>Connection Established : $success_message</b></i></span>"
+
+
 	fi
 fi


### PR DESCRIPTION
 The script does not handle SSIDs with special characters like quotes well due to using `xargs` to select the SSID name. You can fix that by using `read -r` to strip the white spaces instead of `xargs`
 
```bash
# Use rofi to select wifi network
chosen_network=$(echo -e "$toggle\n$wifi_list" | uniq -u | rofi -dmenu -i -selected-row 1 -p "Wi-Fi SSID: " )
# Get name of connection
read -r chosen_id <<< "${chosen_network:3}"
```
 
  PS: I have already made some changes to the notify-send to increase the font size a little bit.